### PR TITLE
Create an alternate temporary directory

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,6 +71,7 @@ test:
     - run_test.py
   commands:
     - python -m numba.runtests
+
 about:
   home: http://numba.github.com
   license: BSD 2-clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,6 +70,7 @@ test:
   files:
     - run_test.py
   commands:
+    - export PYTHONIOENCODING="utf-8"
     - python -m numba.runtests
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,6 +71,8 @@ test:
     - run_test.py
   commands:
     - export PYTHONIOENCODING="utf-8"
+    - export TMPDIR="$(pwd)/temp"
+    - mkdir "${TMPDIR}"
     - python -m numba.runtests
 
 about:


### PR DESCRIPTION
Numba uses a temporary directory as part of its compilation and testing processes. This defaults to `/tmp` on Linux, which uses `tmpfs`. Given this is a Docker container running on a VM, it's possible that this choice of temporary directory is eating into the available memory. So try relocating the temporary directory used to be part of the testing area (mounted from outside the container). Hopefully this avoids eating into the memory limits too quickly and allows testing to proceed.