### PR TITLE
Disable Linux Python 2.7

### DIFF
--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -1,6 +1,0 @@
-pin_run_as_build:
-  python:
-    max_pin: x.x
-    min_pin: x.x
-python:
-- '2.7'

--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -1,10 +1,6 @@
-numpy:
-- '1.9'
 pin_run_as_build:
   python:
     max_pin: x.x
     min_pin: x.x
 python:
 - '2.7'
-scipy:
-- '0.19'

--- a/.ci_support/linux_python3.5.yaml
+++ b/.ci_support/linux_python3.5.yaml
@@ -1,10 +1,6 @@
-numpy:
-- '1.9'
 pin_run_as_build:
   python:
     max_pin: x.x
     min_pin: x.x
 python:
 - '3.5'
-scipy:
-- '0.19'

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -1,10 +1,6 @@
-numpy:
-- '1.9'
 pin_run_as_build:
   python:
     max_pin: x.x
     min_pin: x.x
 python:
 - '3.6'
-scipy:
-- '0.19'

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -4,13 +4,9 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
-numpy:
-- '1.9'
 pin_run_as_build:
   python:
     max_pin: x.x
     min_pin: x.x
 python:
 - '2.7'
-scipy:
-- '0.19'

--- a/.ci_support/osx_python3.5.yaml
+++ b/.ci_support/osx_python3.5.yaml
@@ -4,13 +4,9 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
-numpy:
-- '1.9'
 pin_run_as_build:
   python:
     max_pin: x.x
     min_pin: x.x
 python:
 - '3.5'
-scipy:
-- '0.19'

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -4,13 +4,9 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
-numpy:
-- '1.9'
 pin_run_as_build:
   python:
     max_pin: x.x
     min_pin: x.x
 python:
 - '3.6'
-scipy:
-- '0.19'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,6 @@
 version: 2
 
 jobs:
-  build_linux_python2.7:
-    working_directory: ~/test
-    machine: true
-    environment:
-      - CONFIG: "linux_python2.7"
-    steps:
-      - checkout
-      - run:
-          name: Fast finish outdated PRs and merge PRs
-          command: |
-            ./.circleci/fast_finish_ci_pr_build.sh
-            ./.circleci/checkout_merge_commit.sh
-      - run:
-          command: docker pull condaforge/linux-anvil
-      - run:
-          # Run, test and (if we have a BINSTAR_TOKEN) upload the distributions.
-          command: ./.circleci/run_docker_build.sh
   build_linux_python3.5:
     working_directory: ~/test
     machine: true
@@ -105,7 +88,6 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build_linux_python2.7
       - build_linux_python3.5
       - build_linux_python3.6
       - build_osx_python2.7

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [win]
+  skip: true  # [(linux and py27) or win]
   script: python setup.py install  --single-version-externally-managed --record=record.txt
 
 requirements:


### PR DESCRIPTION
Currently we have some failures in the Python 2.7 tests on Linux. Seems to be a mix of encoding issues, memory errors, and compilation errors. Not totally sure all what is going on there. For now disabling that build to save CI time until someone can look at it more closely.

xref: https://github.com/conda-forge/numba-feedstock/issues/4