### PR TITLE
I think numpy 1.16 is now supported

### DIFF
--- a/.azure-pipelines/run_docker_build.sh
+++ b/.azure-pipelines/run_docker_build.sh
@@ -5,7 +5,7 @@
 # changes to this script, consider a proposal to conda-smithy so that other feedstocks can also
 # benefit from the improvement.
 
-set -xeuo pipefail
+set -xeo pipefail
 
 THISDIR="$( cd "$( dirname "$0" )" >/dev/null && pwd )"
 PROVIDER_DIR="$(basename $THISDIR)"
@@ -28,12 +28,25 @@ fi
 ARTIFACTS="$FEEDSTOCK_ROOT/build_artifacts"
 
 if [ -z "$CONFIG" ]; then
-    echo "Need to set CONFIG env variable"
+    set +x
+    FILES=`ls .ci_support/linux_*`
+    CONFIGS=""
+    for file in $FILES; do
+        CONFIGS="${CONFIGS}'${file:12:-5}' or ";
+    done
+    echo "Need to set CONFIG env variable. Value can be one of ${CONFIGS:0:-4}"
     exit 1
 fi
 
-pip install shyaml
-DOCKER_IMAGE=$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )
+if [ -z "${DOCKER_IMAGE}" ]; then
+    SHYAML_INSTALLED="$(shyaml --version || echo NO)"
+    if [ "${SHYAML_INSTALLED}" == "NO" ]; then
+        echo "WARNING: DOCKER_IMAGE variable not set and shyaml not installed. Falling back to condaforge/linux-anvil-comp7"
+        DOCKER_IMAGE="condaforge/linux-anvil-comp7"
+    else
+        DOCKER_IMAGE="$(cat "${FEEDSTOCK_ROOT}/.ci_support/${CONFIG}.yaml" | shyaml get-value docker_image.0 condaforge/linux-anvil-comp7 )"
+    fi
+fi
 
 mkdir -p "$ARTIFACTS"
 DONE_CANARY="$ARTIFACTS/conda-forge-build-done-${CONFIG}"

--- a/.ci_support/linux_python2.7.yaml
+++ b/.ci_support/linux_python2.7.yaml
@@ -12,6 +12,8 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
+numpy:
+- '1.9'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_python3.6.yaml
+++ b/.ci_support/linux_python3.6.yaml
@@ -12,6 +12,8 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
+numpy:
+- '1.9'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/linux_python3.7.yaml
+++ b/.ci_support/linux_python3.7.yaml
@@ -12,6 +12,8 @@ cxx_compiler_version:
 - '7'
 docker_image:
 - condaforge/linux-anvil-comp7
+numpy:
+- '1.9'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_python2.7.yaml
+++ b/.ci_support/osx_python2.7.yaml
@@ -16,6 +16,8 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
+numpy:
+- '1.9'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_python3.6.yaml
+++ b/.ci_support/osx_python3.6.yaml
@@ -16,6 +16,8 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
+numpy:
+- '1.9'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_python3.7.yaml
+++ b/.ci_support/osx_python3.7.yaml
@@ -16,6 +16,8 @@ macos_machine:
 - x86_64-apple-darwin13.4.0
 macos_min_version:
 - '10.9'
+numpy:
+- '1.9'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.circleci/run_osx_build.sh
+++ b/.circleci/run_osx_build.sh
@@ -2,19 +2,24 @@
 
 set -x
 
-echo "Removing homebrew from Circle CI to avoid conflicts."
+curl https://raw.githubusercontent.com/conda-forge/conda-forge-ci-setup-feedstock/master/recipe/conda_forge_ci_setup/ff_ci_pr_build.py | \
+     python - -v --ci "circle" "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" "${CIRCLE_BUILD_NUM}" "${CIRCLE_PR_NUMBER}"
+
+echo "Removing homebrew from CI to avoid conflicts." && echo -en 'travis_fold:start:remove_homebrew\\r'
 curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
 chmod +x ~/uninstall_homebrew
 ~/uninstall_homebrew -fq
 rm ~/uninstall_homebrew
+echo -en 'travis_fold:end:remove_homebrew\\r'
 
-echo "Installing a fresh version of Miniconda."
+echo "Installing a fresh version of Miniconda." && echo -en 'travis_fold:start:install_miniconda\\r'
 MINICONDA_URL="https://repo.continuum.io/miniconda"
 MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
 curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
 bash $MINICONDA_FILE -b
+echo -en 'travis_fold:end:install_miniconda\\r'
 
-echo "Configuring conda."
+echo "Configuring conda." && echo -en 'travis_fold:start:configure_conda\\r'
 source ~/miniconda3/bin/activate root
 
 conda install -n root -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build
@@ -25,6 +30,7 @@ setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
 source run_conda_forge_build_setup
 
 
+echo -en 'travis_fold:end:configure_conda\\r'
 
 set -e
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Current build status
       <img src="https://img.shields.io/badge/Windows-disabled-lightgrey.svg" alt="Windows disabled">
     </td>
   </tr>
+![ppc64le disabled](https://img.shields.io/badge/ppc64le-disabled-lightgrey.svg)
 </table>
 
 Current release info

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - pip
     - setuptools
     - llvmlite >=0.28.0
-    - numpy 1.16.*
+    - numpy
     - tbb-devel >=2018.0.5  # [linux]
     - enum34          # [py2k]
     - singledispatch  # [py2k]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
     - pip
     - setuptools
     - llvmlite >=0.28.0
-    - numpy 1.15.*    # with numpy 1.16, many tests fail
+    - numpy 1.16.*
     - tbb-devel >=2018.0.5  # [linux]
     - enum34          # [py2k]
     - singledispatch  # [py2k]
@@ -45,7 +45,6 @@ requirements:
     - {{ pin_compatible('llvmlite', max_pin='x.x') }}
     - {{ pin_compatible('numpy') }}
     - llvmlite >=0.28.0
-    - numpy 1.15.*
     - enum34          # [py2k]
     - singledispatch  # [py2k]
     - funcsigs        # [py2k]


### PR DESCRIPTION
I think it is supported

claims that it was in 0.43.1.rc ???
https://github.com/numba/numba/pull/3826


Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
