### PR TITLE
Relax NumPy version constraint

### DIFF
--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -100,13 +100,13 @@ jobs:
       condition: not(contains(variables['CONFIG'], 'vs2008'))
     - script: |
         call activate base
-        validate_recipe_outputs "numba-feedstock"
+        validate_recipe_outputs "numba"
       displayName: Validate Recipe Outputs
 
     - script: |
         set "GIT_BRANCH=%BUILD_SOURCEBRANCHNAME%"
         call activate base
-        upload_package --validate --feedstock-name="numba-feedstock" .\ ".\recipe" .ci_support\%CONFIG%.yaml
+        upload_package --validate --feedstock-name="numba" .\ ".\recipe" .ci_support\%CONFIG%.yaml
       displayName: Upload package
       env:
         BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @henryiii @marcelotrevisani @mbargull @souravsingh
+* @henryiii @jakirkham @marcelotrevisani @mbargull @souravsingh

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,10 +31,10 @@ make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
     --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-validate_recipe_outputs "numba-feedstock"
+validate_recipe_outputs "numba"
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
-    upload_package --validate --feedstock-name="numba-feedstock" "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
+    upload_package --validate --feedstock-name="numba" "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 fi
 
 touch "${FEEDSTOCK_ROOT}/build_artifacts/conda-forge-build-done-${CONFIG}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -48,9 +48,9 @@ set -e
 echo -e "\n\nMaking the build clobber file and running the build."
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
-validate_recipe_outputs "numba-feedstock"
+validate_recipe_outputs "numba"
 
 if [[ "${UPLOAD_PACKAGES}" != "False" ]]; then
   echo -e "\n\nUploading the packages."
-  upload_package --validate --feedstock-name="numba-feedstock" ./ ./recipe ./.ci_support/${CONFIG}.yaml
+  upload_package --validate --feedstock-name="numba" ./ ./recipe ./.ci_support/${CONFIG}.yaml
 fi

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Feedstock Maintainers
 =====================
 
 * [@henryiii](https://github.com/henryiii/)
+* [@jakirkham](https://github.com/jakirkham/)
 * [@marcelotrevisani](https://github.com/marcelotrevisani/)
 * [@mbargull](https://github.com/mbargull/)
 * [@souravsingh](https://github.com/souravsingh/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - pycc = numba.pycc:main
     - numba = numba.misc.numba_entry:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,6 +61,9 @@ test:
     # Need these for AOT. Do not init msvc as it may not be present
     - {{ compiler('c') }}      # [not win]
     - {{ compiler('cxx') }}    # [not win]
+    # Needed to bypass some datetime test failures.
+    # Drop when Numba 0.50.0 is released
+    - numpy <1.18
 
   imports:
     - numba

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -113,3 +113,4 @@ extra:
     - marcelotrevisani
     - henryiii
     - mbargull
+    - jakirkham

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ requirements:
   run:
     - python
     - llvmlite >=0.31.0,<0.33
-    - {{ pin_compatible('numpy', upper_bound='1.18.0') }}
+    - {{ pin_compatible('numpy') }}
     # needed for pkg_resources
     - setuptools
 


### PR DESCRIPTION
As discussed in the xref'd PR, we are relaxing the `numpy` version constraint here to fix some solver issues people will otherwise encounter installing the latest `numba` version.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

cc @stuartarchibald @isuruf @beckermr @henryiii @jjhelmus

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

xref: https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/51
