### PR TITLE
Support TBB on non-Linux, skip PyPy

### DIFF
--- a/.ci_support/linux_64_numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.16python3.6.____cpython.yaml
@@ -22,6 +22,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.6.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - linux-64
 tbb:
@@ -33,3 +35,4 @@ zip_keys:
   - docker_image
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/linux_64_numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.16python3.7.____cpython.yaml
@@ -22,6 +22,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.7.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - linux-64
 tbb:
@@ -33,3 +35,4 @@ zip_keys:
   - docker_image
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/linux_64_numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.16python3.8.____cpython.yaml
@@ -22,6 +22,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.8.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - linux-64
 tbb:
@@ -33,3 +35,4 @@ zip_keys:
   - docker_image
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.19python3.9.____cpython.yaml
@@ -22,6 +22,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.9.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - linux-64
 tbb:
@@ -33,3 +35,4 @@ zip_keys:
   - docker_image
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/linux_aarch64_numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.16python3.6.____cpython.yaml
@@ -26,10 +26,15 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.6.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - linux-aarch64
+tbb:
+- '2020'
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/linux_aarch64_numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.16python3.7.____cpython.yaml
@@ -26,10 +26,15 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.7.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - linux-aarch64
+tbb:
+- '2020'
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/linux_aarch64_numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.16python3.8.____cpython.yaml
@@ -26,10 +26,15 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.8.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - linux-aarch64
+tbb:
+- '2020'
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/linux_aarch64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.19python3.9.____cpython.yaml
@@ -26,10 +26,15 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.9.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - linux-aarch64
+tbb:
+- '2020'
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/linux_ppc64le_numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.16python3.6.____cpython.yaml
@@ -22,6 +22,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.6.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - linux-ppc64le
 tbb:
@@ -31,3 +33,4 @@ zip_keys:
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/linux_ppc64le_numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.16python3.7.____cpython.yaml
@@ -22,6 +22,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.7.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - linux-ppc64le
 tbb:
@@ -31,3 +33,4 @@ zip_keys:
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/linux_ppc64le_numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.16python3.8.____cpython.yaml
@@ -22,6 +22,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.8.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - linux-ppc64le
 tbb:
@@ -31,3 +33,4 @@ zip_keys:
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/linux_ppc64le_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/linux_ppc64le_numpy1.19python3.9.____cpython.yaml
@@ -22,6 +22,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.9.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - linux-ppc64le
 tbb:
@@ -31,3 +33,4 @@ zip_keys:
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/osx_64_numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.16python3.6.____cpython.yaml
@@ -22,6 +22,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.6.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - osx-64
 tbb:
@@ -31,3 +33,4 @@ zip_keys:
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/osx_64_numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.16python3.7.____cpython.yaml
@@ -22,6 +22,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.7.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - osx-64
 tbb:
@@ -31,3 +33,4 @@ zip_keys:
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/osx_64_numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.16python3.8.____cpython.yaml
@@ -22,6 +22,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.8.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - osx-64
 tbb:
@@ -31,3 +33,4 @@ zip_keys:
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.19python3.9.____cpython.yaml
@@ -22,6 +22,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.9.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - osx-64
 tbb:
@@ -31,3 +33,4 @@ zip_keys:
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/osx_arm64_python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.8.____cpython.yaml
@@ -22,6 +22,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.8.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - osx-arm64
 tbb:
@@ -31,3 +33,4 @@ zip_keys:
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/osx_arm64_python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_python3.9.____cpython.yaml
@@ -22,6 +22,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.9.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - osx-arm64
 tbb:
@@ -31,3 +33,4 @@ zip_keys:
   - cxx_compiler_version
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/win_64_numpy1.16python3.6.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.16python3.6.____cpython.yaml
@@ -14,6 +14,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.6.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - win-64
 tbb:
@@ -21,3 +23,4 @@ tbb:
 zip_keys:
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/win_64_numpy1.16python3.7.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.16python3.7.____cpython.yaml
@@ -14,6 +14,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.7.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - win-64
 tbb:
@@ -21,3 +23,4 @@ tbb:
 zip_keys:
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/win_64_numpy1.16python3.8.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.16python3.8.____cpython.yaml
@@ -14,6 +14,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.8.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - win-64
 tbb:
@@ -21,3 +23,4 @@ tbb:
 zip_keys:
 - - python
   - numpy
+  - python_impl

--- a/.ci_support/win_64_numpy1.19python3.9.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.19python3.9.____cpython.yaml
@@ -14,6 +14,8 @@ pin_run_as_build:
     max_pin: x.x
 python:
 - 3.9.* *_cpython
+python_impl:
+- cpython
 target_platform:
 - win-64
 tbb:
@@ -21,3 +23,4 @@ tbb:
 zip_keys:
 - - python
   - numpy
+  - python_impl

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About numba
 ===========
 
-Home: http://numba.github.com
+Home: http://numba.pydata.org
 
 Package license: BSD-2-Clause
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,7 +68,7 @@ test:
     - scipy
     - ipython
     - setuptools
-    - tbb >=2018.0.5
+    - tbb >=2019.5
     - intel-openmp             # [osx]
     # Need these for AOT. Do not init msvc as it may not be present
     - {{ compiler('c') }}      # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - pycc = numba.pycc:main
     - numba = numba.misc.numba_entry:main
@@ -20,7 +20,7 @@ build:
     - {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv
   ignore_run_exports:
     # tbb-devel triggers hard dependency on tbb, this is not the case.
-    - tbb  # [not (armv6l or armv7l or aarch64 or linux32)]
+    - tbb
 
 requirements:
   build:
@@ -38,7 +38,7 @@ requirements:
     - setuptools
     - llvmlite 0.36.*
     - numpy
-    - tbb-devel >=2019.5,<=2020.3  # [linux64 or ppc64le]
+    - tbb-devel >=2019.5,<=2020.3
 
   run:
     - python
@@ -52,7 +52,7 @@ requirements:
     # build flag issues triggering UB. It must also be <=2020.3 due to ABI
     # changes in TBB, see https://github.com/numba/numba/pull/6096.
     # 2020.3 is the last version with the "old" ABI
-    - tbb  >=2019.5,<=2020.3  # [linux64 or ppc64le]
+    - tbb  >=2019.5,<=2020.3
     # avoid confusion from openblas bugs
     - libopenblas !=0.3.6      # [x86_64]
     # CUDA 9.0 or later is required for CUDA support
@@ -68,7 +68,7 @@ test:
     - scipy
     - ipython
     - setuptools
-    - tbb >=2018.0.5           # [linux64 or ppc64le]
+    - tbb >=2018.0.5
     - intel-openmp             # [osx]
     # Need these for AOT. Do not init msvc as it may not be present
     - {{ compiler('c') }}      # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ build:
   ignore_run_exports:
     # tbb-devel triggers hard dependency on tbb, this is not the case.
     - tbb
+  skip: True  # [python_impl == 'pypy']
 
 requirements:
   build:
@@ -107,7 +108,7 @@ test:
     - numba.tests.npyufunc
 
 about:
-  home: http://numba.github.com
+  home: http://numba.pydata.org
   license: BSD-2-Clause
   license_family: BSD
   license_file: LICENSE

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -38,7 +38,7 @@ python -m numba.tests.test_runtests
 
 if [[ "$archstr" == 'aarch64' ]]; then
 	echo 'Running only a slice of tests'
-	$SEGVCATCH python -m numba.runtests -b -j --random='0.20' --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
+	$SEGVCATCH python -m numba.runtests -b -j --random='0.10' --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
 # For now, skip tests on ppc64le because of known errors in the testing suite on ppc64le https://github.com/numba/numba/issues/4026
 elif [[ "$archstr" == 'ppc64le' ]]; then
 	echo 'Skipping tests on ppc64le for testing'

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -38,7 +38,7 @@ python -m numba.tests.test_runtests
 
 if [[ "$archstr" == 'aarch64' ]]; then
 	echo 'Running only a slice of tests'
-	$SEGVCATCH python -m numba.runtests -b -j --random='0.10' --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
+	$SEGVCATCH python -m numba.runtests -b -j --random='0.15' --exclude-tags='long_running' -m $TEST_NPROCS -- numba.tests
 # For now, skip tests on ppc64le because of known errors in the testing suite on ppc64le https://github.com/numba/numba/issues/4026
 elif [[ "$archstr" == 'ppc64le' ]]; then
 	echo 'Skipping tests on ppc64le for testing'


### PR DESCRIPTION
Explicit skip for PyPy added, testing out including TBB (closes #43), and update the test line for TBB (closes #63). Also fixed the homepage link; GitHub will turn off the old redirects at some point.


- feat: add tbb on macOS/win
- fix: tbb min version match
- fix: explicit skip for PyPy
