### PR TITLE
Pin setuptools<60

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - pycc = numba.pycc:main
     - numba = numba.misc.numba_entry:main
@@ -39,7 +39,7 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
+    - setuptools <60
     - llvmlite 0.39.*
     - numpy
     - tbb-devel 2021.*,<2021.6
@@ -50,7 +50,7 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - importlib-metadata  # [py < 39]
     # needed for pkg_resources
-    - setuptools
+    - setuptools <60
 
   run_constrained:
     - tbb  2021.*  # [not (armv6l or armv7l or aarch64 or linux32 or ppc64le)]


### PR DESCRIPTION
See https://github.com/numba/numba/commit/454fe25b0f0ebf0e85e7dc1fa8a6fab50157adcd

This fixes all the failing `pip check` calls in downstream packages.

Related discussion in [yesterday](https://github.com/conda-forge/numba-feedstock/pull/94#discussion_r982039697)

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
