### PR TITLE
Remove setuptools constraint

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -111,9 +111,6 @@ test:
     - numba.tests
     - numba.tests.npyufunc
 
-  commands:
-    - pip check
-
 about:
   home: http://numba.pydata.org
   license: BSD-2-Clause

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,11 @@ source:
   # url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   url: https://github.com/numba/{{ name }}/archive/{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    - patch-setuptools-60.patch
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - pycc = numba.pycc:main
     - numba = numba.misc.numba_entry:main

--- a/recipe/patch-setuptools-60.patch
+++ b/recipe/patch-setuptools-60.patch
@@ -1,0 +1,14 @@
+diff --git a/setup.py b/setup.py
+index 2a6d12277..68feca4b2 100644
+--- a/setup.py
++++ b/setup.py
+@@ -375,7 +375,7 @@ build_requires = ['numpy >={},<{}'.format(min_numpy_build_version,
+ install_requires = [
+     'llvmlite >={},<{}'.format(min_llvmlite_version, max_llvmlite_version),
+     'numpy >={},<{}'.format(min_numpy_run_version, max_numpy_run_version),
+-    'setuptools<60',
++    'setuptools',
+     'importlib_metadata; python_version < "3.9"',
+ ]
+ 
+

--- a/recipe/run_test.bat
+++ b/recipe/run_test.bat
@@ -15,3 +15,6 @@ python -m numba.tests.test_runtests
 python -m numba.runtests -m %CPU_COUNT% -b
 
 if errorlevel 1 exit 1
+
+python -m pip check
+if errorlevel 1 exit 1

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -60,3 +60,5 @@ else
 	echo "Running: $SEGVCATCH python -m numba.runtests -b -m $TEST_NPROCS -- $TESTS_TO_RUN"
 $SEGVCATCH python -m numba.runtests -b --exclude-tags='long_running' -m $TEST_NPROCS -- $TESTS_TO_RUN
 fi
+
+pip check


### PR DESCRIPTION
Based on and closes #105 with the setuptools constraint removed from setup.py in an attempt to make `pip check` succeed. I expect a further patch to some tests may be required.

Closes #104 too.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
