### PR TITLE
Fix `tbb-devel` pin

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - setuptools
     - llvmlite 0.40.*
     - numpy
-    - tbb-devel >=2021.6.0
+    - tbb-devel 2021.6.0
 
   run:
     - python
@@ -50,7 +50,7 @@ requirements:
     - importlib-metadata  # [py < 39]
 
   run_constrained:
-    - {{ pin_compatible('tbb') }}
+    - {{ pin_compatible('tbb', max_pin=None) }}
     # avoid confusion from openblas bugs
     - libopenblas !=0.3.6             # [x86_64]
     - libopenblas >=0.3.18, !=0.3.20  # [arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   entry_points:
     - numba = numba.misc.numba_entry:main
   script:


### PR DESCRIPTION
Ensure a specific version of `tbb-devel` is used during the build while relaxing the pin in `run_constrained` to handle versions from later years as well.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

xref: https://github.com/conda-forge/numba-feedstock/pull/123#discussion_r1217106658